### PR TITLE
Switch deploy script to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION="eu-west-1"
+BUCKET="opengazettes.or.ke"

--- a/README.md
+++ b/README.md
@@ -14,14 +14,19 @@ The structure is simple. Each jurisdiction (country/province) and year has an en
 
 To update this list from the production index:
 
-    curl http://archive.opengazettes.or.ke/index/gazette-index-latest.jsonlines -O
+    curl https://s3-eu-west-1.amazonaws.com/cfa-opengazettes-ke/gazettes/data.jsonlines -O
     python bin/build-index.py
 
-# Build process
+# Deploying to S3
 
-The website is built automatically by GitHub pages based on the Gazette information already in the repository.
+The website is deployed to S3 using [s3_website](https://github.com/laurilehmijoki/s3_website)
 
-The [build branch](https://github.com/OpenGazettes/OpenGazettes/tree/build) has code that updates the information in the repository from the Gazette index in S3. A Travis build for this branch is triggered automatically when we archive new Gazettes in S3.
+To deploy:
+
+- Make a copy of the `.env.example` file and name it `.env`
+- Add your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the `.env` file
+- Run `./deploy.sh` from the root directory
+- You're done!
 
 # License
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,11 +10,6 @@
 
 # Initialize some vars
 . .env
-export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
-export AWS_DEFAULT_REGION="eu-west-1"
-export BUCKET="opengazettes.or.ke"
-
 export DEPLOY_DIR=".deploy"
 
 bundle exec jekyll build

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@
 # Usage:
 #   ./deploy.sh
 #
-# This script get the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from your .env file
+# This script gets the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from your .env file
 # It will fail if those are not present
 
 # Initialize some vars

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,11 +3,15 @@
 # Cleans and deploys the project to S3.
 #
 # Usage:
-#   ./deploy.sh <AWS_ACCESS_KEY_ID> <AWS_SECRET_ACCESS_KEY>
+#   ./deploy.sh
+#
+# This script get the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from your .env file
+# It will fail if those are not present
 
 # Initialize some vars
-export AWS_ACCESS_KEY_ID="$1"
-export AWS_SECRET_ACCESS_KEY="$2"
+. .env
+export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
 export AWS_DEFAULT_REGION="eu-west-1"
 export BUCKET="opengazettes.or.ke"
 
@@ -15,8 +19,8 @@ export DEPLOY_DIR=".deploy"
 
 bundle exec jekyll build
 
-# Copy the site directory to a temporary location so that modifications we make don't get overwritten by the Jekyll server
-# that is potentially running
+# Copy the site directory to a temporary location so that modifications we make 
+# don't get overwritten by the Jekyll server that is potentially running
 mkdir -p $DEPLOY_DIR
 cp -a _site/. $DEPLOY_DIR
 


### PR DESCRIPTION
 * Script now expects AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be
   set in the .env file